### PR TITLE
Adding example for guava optional isEqual assertions.

### DIFF
--- a/assertions-examples/src/test/java/org/assertj/examples/guava/OptionalAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/guava/OptionalAssertionsExamples.java
@@ -34,6 +34,12 @@ public class OptionalAssertionsExamples extends AbstractAssertionsExamples {
 
     Optional<Object> absentOptional = Optional.fromNullable(null);
     assertThat(absentOptional).isAbsent();
+
+    Optional<String> equalValueOptional = Optional.of("Test");
+    assertThat(optional).isEqualTo(equalValueOptional);
+
+    Optional<Object> anotherAbsentOptional = Optional.fromNullable(null);
+    assertThat(absentOptional).isEqualTo(anotherAbsentOptional);
     
     // log some error messages to have a look at them
     try {
@@ -53,6 +59,16 @@ public class OptionalAssertionsExamples extends AbstractAssertionsExamples {
     }
     try {
       assertThat(optional).isAbsent();
+    } catch (AssertionError e) {
+      logAssertionErrorMessage("OptionalAssert.isAbsent", e);
+    }
+    try {
+      assertThat(optional).isEqualTo(absentOptional);
+    } catch (AssertionError e) {
+      logAssertionErrorMessage("OptionalAssert.isAbsent", e);
+    }
+    try {
+      assertThat(optional).isEqualTo(Optional.of("Different"));
     } catch (AssertionError e) {
       logAssertionErrorMessage("OptionalAssert.isAbsent", e);
     }


### PR DESCRIPTION
Examples for isEqualTo assertion on guava optionals.

Sibling to pull request submitted to that project:
https://github.com/joel-costigliola/assertj-guava/pull/7

Feedback welcome,

Thanks - Andrew.
