### PR TITLE
Adapt to AbstractClassAssert#hasFields rename to hasPublicFields

### DIFF
--- a/assertions-examples/src/test/java/org/assertj/examples/ClassAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/ClassAssertionsExamples.java
@@ -74,12 +74,12 @@ public class ClassAssertionsExamples extends AbstractAssertionsExamples {
 
   @Test
   public void field_examples() {
-    assertThat(TolkienCharacter.class).hasFields("age");
+    assertThat(TolkienCharacter.class).hasPublicFields("age");
 
     try {
-      assertThat(TolkienCharacter.class).hasFields("aliases");
+      assertThat(TolkienCharacter.class).hasPublicFields("aliases");
     } catch (AssertionError e) {
-      logAssertionErrorMessage("hasFields", e);
+      logAssertionErrorMessage("hasPublicFields", e);
     }
   }
 


### PR DESCRIPTION
Java 7 "with snapshots" examples fail to compile with current "2.x" branch due to hasFields rename to hasPublicFields. This fixes the issue.